### PR TITLE
minor prereq change

### DIFF
--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -4,7 +4,7 @@ data:extend({
     name = "pollution-detection",
     icon = "__pollution-detector__/graphics/technology/pollution-detection.png",
     icon_size = 256,
-    prerequisites = {"plastics", "advanced-circuit"},
+    prerequisites = {"circuit-network"},
     effects =
     {
       {


### PR DESCRIPTION
changes pollution-detection tech prereq to circuit-network so all recipe ingredients must be unlocked before the pollution-detector recipe